### PR TITLE
Link to correct site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # harbour-tox
 Tox client for Sailfish OS on Jolla phone
 
-This is now a first version of Tox (https://tox.im/) client for Sailfish OS, it may be able to send and receive text message. I did not test it for a long time on my Jolla and it may drain the battery... Current version must be launched from command line in a writable directory.
+This is now a first version of Tox (https://tox.chat/) client for Sailfish OS, it may be able to send and receive text message. I did not test it for a long time on my Jolla and it may drain the battery... Current version must be launched from command line in a writable directory.
 
 All others tox features are yet missing :
  - File transfert & avatars


### PR DESCRIPTION
The former domain has been seized by a rogue third party and is NOT affiliated with the Tox project and its developers. 

The website of the Tox project is https://tox.chat. For explanation see https://blog.tox.chat/2015/07/current-situation-3/ and for verification ask around in #tox-dev on freenode.

Thank you!
